### PR TITLE
Feature/add redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ http://localhost:8080/api/hello
 
 ---
 
+## Redis
+Avant de démarrer l'application Spring Boot, il est nécessaire de faire tourner Redis dans un conteneur Docker.
+
+### 1. Lancer Redis avec Docker Compose
+Dans le répertoire du projet, exécutez la commande suivante pour démarrer Redis :
+
+```bash
+docker-compose up
+```
+Cela démarrera Redis dans un conteneur, accessible à l'adresse http://localhost:6379.
+
+### 2. Lancer l'application Spring Boot
+Une fois Redis lancé, vous pouvez démarrer l'application Spring Boot comme d'habitude :
+
+```bash
+mvn spring-boot:run
+```
+
+---
+
 ## Swagger UI
 
 - **Swagger UI** est disponible à l'adresse suivante : 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  redis:
+    image: redis:latest
+    container_name: redis
+    environment:
+      - REDIS_PASSWORD=password
+    ports:
+      - "6379:6379"
+    networks:
+      - teamoop-network
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "my-strong-password"]
+
+networks:
+  teamoop-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,11 @@ services:
   redis:
     image: redis:latest
     container_name: redis
-    environment:
-      - REDIS_PASSWORD=password
     ports:
       - "6379:6379"
     networks:
       - teamoop-network
-    command: ["redis-server", "--appendonly", "yes", "--requirepass", "my-strong-password"]
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "password"]
 
 networks:
   teamoop-network:

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/src/main/java/com/edj/teamoop/config/CacheConfig.java
+++ b/src/main/java/com/edj/teamoop/config/CacheConfig.java
@@ -1,0 +1,27 @@
+package com.edj.teamoop.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import java.time.Duration;
+
+@Configuration
+public class CacheConfig {
+
+    @Value("${redis.ttl.duration}")
+    private Duration RedisTTL;
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(RedisTTL);
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/src/main/java/com/edj/teamoop/config/RedisConfig.java
+++ b/src/main/java/com/edj/teamoop/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package com.edj.teamoop.config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.resource.ClientResources;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${redis.host}")
+    private String redisHost;
+
+    @Value("${redis.port}")
+    private int redisPort;
+
+    @Value("${redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPort(redisPort);
+        redisStandaloneConfiguration.setPassword(redisPassword);
+
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .clientOptions(ClientOptions.builder()
+                        .disconnectedBehavior(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS)
+                        .build())
+                .clientResources(ClientResources.create())
+                .build();
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration, clientConfig);
+    }
+}
+

--- a/src/main/java/com/edj/teamoop/config/SecurityConfig.java
+++ b/src/main/java/com/edj/teamoop/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfig.corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/api/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/api/**", "/actuator/**").permitAll()
                         .anyRequest().authenticated());
 
         return http.build();

--- a/src/main/java/com/edj/teamoop/service/cache/CacheService.java
+++ b/src/main/java/com/edj/teamoop/service/cache/CacheService.java
@@ -1,0 +1,10 @@
+package com.edj.teamoop.service.cache;
+
+import java.util.Optional;
+
+public interface CacheService<T, ID> {
+    Optional<T> getCachedEntity(ID id);
+    T saveAndEvictCache(T entity);
+    void deleteAndEvictCache(ID id);
+    void clearAllCache();
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,11 @@
+# spring.datasource.url=jdbc:postgresql://localhost:5432/teamoopDB
+# spring.datasource.username=utilisateur
+# spring.datasource.password=mot_de_passe
+# spring.jpa.hibernate.ddl-auto=update
+# spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+# spring.jpa.show-sql=true
+
+redis.host=localhost
+redis.port=6379
+redis.password=password
+redis.ttl.duration=10m

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,4 @@
+redis.host=localhost
+redis.port=6379
+redis.password=password
+redis.ttl.duration-=10m

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,6 @@
 spring.application.name=teamoop
 spring.security.enabled=false
-
-## Database
-# spring.datasource.url=jdbc:postgresql://localhost:5432/teamoopDB
-# spring.datasource.username=utilisateur
-# spring.datasource.password=mot_de_passe
-# spring.jpa.hibernate.ddl-auto=update
-# spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-# spring.jpa.show-sql=true
+spring.profiles.active=dev
 
 ##Actuator
 management.endpoints.web.exposure.include=health,info
@@ -20,5 +13,4 @@ cors.allowed.origin=http://localhost:4200
 # logging.level.org.springframework.security=DEBUG
 # logging.level.org.springframework.web.cors=DEBUG
 # logging.level.org.springdoc=DEBUG
-
-
+logging.level.org.springframework.data.redis=DEBUG


### PR DESCRIPTION
## Intégration de Redis

### [Ticket](https://trello.com/c/RFNYrdKg/5-int%C3%A9grer-redis-pour-g%C3%A9rer-le-cache-des-donn%C3%A9es)

### Objectif
- Mettre en place une BDD Redis avec `docker-compose` pour gérer le cache.
- Configurer la connection de spring à redis
- Créer un config de gestion de vie des objets en cache (ttl)
- J'ai aussi créé un interface cacheService qui nous servira à implémenter des classes métiers pour gérer le cache.